### PR TITLE
Lazy request for properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Or install it yourself as:
 
   You can find all the country property keys [here](http://wifo5-04.informatik.uni-mannheim.de/factbook/page/venezuela) and a running example on a rails application [here](https://github.com/alphadeville/mil1-api).
 
+  * Note: properties will be lazy returned, so a request to the RDF server will be fired only at the first execution of `get_property` method.
+
 ## Roadmap
 
 * Implement HTML request approach.

--- a/lib/the_country_identity/rdf.rb
+++ b/lib/the_country_identity/rdf.rb
@@ -6,46 +6,38 @@ module TheCountryIdentity
     @@URI_PREFIX       = 'http://wifo5-03.informatik.uni-mannheim.de/factbook/data/'
     @@STATEMENT_PREFIX = 'http://wifo5-04.informatik.uni-mannheim.de/factbook/ns#'
 
+    attr_accessor :cache
     attr_reader   :country_name
     attr_reader   :url
-    attr_reader   :repo
-    attr_accessor :data
+    attr_reader   :repository
 
-    def initialize(new_country_name)
-      fetch_country new_country_name
+    def initialize(country_name)
+      @cache = {}
+      @country_name = country_name.downcase.gsub(' ', '_').gsub('usa', 'united_states')
+      @url = @@URI_PREFIX + @country_name
     end
 
     def get_property(property_name)
-      return @data[property_name] if @data[property_name]
+      return @cache[property_name] if @cache[property_name]
 
-      unless @repo.nil?
-        options = { :predicate => ::RDF::URI("#{@@STATEMENT_PREFIX}#{property_name}") }
-        @repo.query(options) do |stmnt|
-          @data[property_name] = stmnt.object.value
+      begin
+        unless repo.nil?
+          options = { :predicate => ::RDF::URI("#{@@STATEMENT_PREFIX}#{property_name}") }
+          repo.query(options) do |stmnt|
+            @cache[property_name] = stmnt.object.value
+          end
         end
+      rescue => e
+        puts "Not able to get country information, through exception: #{e}"
       end
 
-      @data[property_name]
-    end
-
-    def fetch_country(country_name)
-      @data = {}
-      unless country_name.nil?
-        @country_name = country_name.downcase.gsub(' ', '_').gsub('usa', 'united_states')
-        @url = @@URI_PREFIX + @country_name
-
-        begin
-          fetch_rdf
-        rescue => e
-          puts "Not able to get country information, through exception: #{e}"
-        end
-      end
+      @cache[property_name]
     end
 
     private
 
-      def fetch_rdf
-        @repo = ::RDF::Repository.load(@url)
+      def repo
+        @repository ||= ::RDF::Repository.load(@url)
       end
 
   end

--- a/lib/the_country_identity/version.rb
+++ b/lib/the_country_identity/version.rb
@@ -1,3 +1,3 @@
 module TheCountryIdentity
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/spec/the_country_identity_rdf_spec.rb
+++ b/spec/the_country_identity_rdf_spec.rb
@@ -22,13 +22,14 @@ describe TheCountryIdentity do
       expect(@country.url).to eq 'http://wifo5-03.informatik.uni-mannheim.de/factbook/data/operation_treadstone'
     end
 
-    it 'sets correct repo (RDF::Repository)' do
-      expect(@country.repo).to be_nil
+    it 'sets correct repository (RDF::Repository)' do
+      @country.get_property('lifeexpectancyatbirth_totalpopulation')
+      expect(@country.repository).to be_nil
     end
 
-    it 'sets initial value for cached data' do
-      expect(@country.data).to be_instance_of(Hash)
-      expect(@country.data.empty?).to be_truthy
+    it 'sets initial value to be cached' do
+      expect(@country.cache).to be_instance_of(Hash)
+      expect(@country.cache.empty?).to be_truthy
     end
 
     it 'returns nil value for a given property' do
@@ -58,19 +59,20 @@ describe TheCountryIdentity do
       expect(@country.url).to eq 'http://wifo5-03.informatik.uni-mannheim.de/factbook/data/venezuela'
     end
 
-    it 'sets correct repo (RDF::Repository)' do
-      expect(@country.repo).to be_instance_of(::RDF::Repository)
-      expect(@country.repo.readable?).to be_truthy
-      expect(@country.repo.writable?).to be_truthy
-      expect(@country.repo.persistent?).to be_falsey
-      expect(@country.repo.transient?).to be_truthy
-      expect(@country.repo.empty?).to be_falsey
-      expect(@country.repo.count).to be 197
+    it 'sets correct repository (RDF::Repository)' do
+      @country.get_property('lifeexpectancyatbirth_totalpopulation')
+      expect(@country.repository).to be_instance_of(::RDF::Repository)
+      expect(@country.repository.readable?).to be_truthy
+      expect(@country.repository.writable?).to be_truthy
+      expect(@country.repository.persistent?).to be_falsey
+      expect(@country.repository.transient?).to be_truthy
+      expect(@country.repository.empty?).to be_falsey
+      expect(@country.repository.count).to be 197
     end
 
-    it 'sets initial value for cached data' do
-      expect(@country.data).to be_instance_of(Hash)
-      expect(@country.data.empty?).to be_truthy
+    it 'sets initial value to be cached' do
+      expect(@country.cache).to be_instance_of(Hash)
+      expect(@country.cache.empty?).to be_truthy
     end
 
     it 'returns a custom value for a given property' do
@@ -78,14 +80,14 @@ describe TheCountryIdentity do
       life_expectancy = @country.get_property(property)
       expect(life_expectancy).to be_instance_of(String)
       expect(life_expectancy).to eq '73.28E0'
-      expect(@country.data[property]).to eq '73.28E0'
+      expect(@country.cache[property]).to eq '73.28E0'
     end
 
     it 'returns nil value for a given unknown property' do
       property = 'operation_blackbriar'
       life_expectancy = @country.get_property(property)
       expect(life_expectancy).to be_nil
-      expect(@country.data[property]).to be_nil
+      expect(@country.cache[property]).to be_nil
     end
 
   end


### PR DESCRIPTION
Refactor to lazy return properties instead of fetch the whole RDF document when the RDF object is instantiated.
